### PR TITLE
MAINT: Update patch classification output type

### DIFF
--- a/infer/tile.py
+++ b/infer/tile.py
@@ -281,10 +281,10 @@ class InferManager(base.InferManager):
                 )
             
             if pclass_map is not None:
-                mkdir("%s/pclass/" % save_root_dir)
-                cv2.imwrite(
-                    "%s/pclass/%s.png" % (save_root_dir, base_name),
-                    pclass_map)
+                mkdir("%s/pclass_mat/" % save_root_dir)
+                sio.savemat(
+                    "%s/pclass_mat/%s.mat" % (save_root_dir, base_name),
+                    {"pclass": pclass_map})
             return
 
         proc_pool = None


### PR DESCRIPTION
Change the output data format in `tile` mode to `.mat` file, in line with the other outputs.