### PR TITLE
MAINT: Remove hard-coded cache-patch argument in WSI mode

### DIFF
--- a/run_infer_wsi.py
+++ b/run_infer_wsi.py
@@ -49,8 +49,6 @@ from misc.utils import rm_n_mkdir
 if __name__ == "__main__":
     args = docopt(__doc__, version="CoBi Gland Inference")
 
-    args["--cache_path"] = "/root/dgx_workspace/cache/"
-
     if args["--gpu"]:
        os.environ["CUDA_VISIBLE_DEVICES"] = args["--gpu"]
 

--- a/run_wsi.sh
+++ b/run_wsi.sh
@@ -4,4 +4,5 @@ python run_infer_wsi.py \
 --model="/root/romesco_workspace/resnet34_cerberus" \
 --input_dir="wsi_test/" \
 --output_dir="output_test/"
+--cache_path="/root/dgx_workspace/cache" \ # ensure on SSD for optimal processing!
 --save_thumb


### PR DESCRIPTION
`--cache_path` was hard-coded in `run_infer_wsi.py`. This PR removes the hard-coding to prevent the issue in the future.