### PR TITLE
BUG: Fix `base_mag` not found and thumbnail generation errors

### DIFF
--- a/infer/wsi.py
+++ b/infer/wsi.py
@@ -524,7 +524,7 @@ class InferManager(base.InferManager):
         self.wsi_proc_shape = self.wsi_proc_shape[::-1]
         
         self.wsi_base_mag = self.wsi_handler.info.mpp # get scan resolution of WSI
-        self.wsi_base_shape = self.wsi_handler.slide_dimensions({"resolution": self.base_mag, "units": "mpp"})
+        self.wsi_base_shape = self.wsi_handler.slide_dimensions(self.wsi_base_mag, "mpp")
         self.wsi_base_shape = self.wsi_base_shape[::-1] # to YX
 
         if mask_path is not None and os.path.isfile(mask_path):
@@ -539,7 +539,7 @@ class InferManager(base.InferManager):
             cv2.imwrite(f"{self.output_dir}/mask/{wsi_basename}.png", self.wsi_mask*255)
         if self.save_thumb:
             # thumbnail at 1.25x objective magnification
-            wsi_thumb = self.slide_thumbnail(resolution=1.25, units="power") 
+            wsi_thumb = self.wsi_handler.slide_thumbnail(resolution=1.25, units="power") 
             cv2.imwrite(f"{self.output_dir}/thumb/{wsi_basename}.png", wsi_thumb)
             
         # warning, the value within this is uninitialized

--- a/run_wsi.sh
+++ b/run_wsi.sh
@@ -1,8 +1,8 @@
 python run_infer_wsi.py \
 --gpu="0" \
---batch_size=25 \ # dependent on hardware
+--batch_size=25 \
 --model="/root/romesco_workspace/resnet34_cerberus" \
 --input_dir="wsi_test/" \
---output_dir="output_test/"
---cache_path="/root/dgx_workspace/cache" \ # ensure on SSD for optimal processing!
+--output_dir="output_test/" \
+--cache_path="/root/dgx_workspace/cache" \
 --save_thumb


### PR DESCRIPTION
In this PR, we fix the following:

- `base_mag` not found error -> should be `wsi_base_mag`
- slide_thumbnail was incorrectly called

This PR was created as a result of #7 
